### PR TITLE
Security v9.1: Cosign Keyless Signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,3 +65,32 @@ jobs:
         with:
           image: ghcr.io/${{ env.IMAGE_OWNER }}/atlas-witness:${{ github.ref_name }}
           format: spdx-json
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Resolve digests (gateway & witness)
+        id: dig
+        uses: imjasonh/setup-crane@v0.4
+      - run: |
+          echo "gw=$(crane digest ghcr.io/${{ github.repository_owner }}/atlas-gateway:${{ github.ref_name }})" >> $GITHUB_OUTPUT
+          echo "wt=$(crane digest ghcr.io/${{ github.repository_owner }}/atlas-witness:${{ github.ref_name }})" >> $GITHUB_OUTPUT
+        id: digests
+
+      - name: Cosign sign (gateway: tag + digest)
+        env:
+          COSIGN_EXPERIMENTAL: 1
+        run: |
+          cosign sign --yes \
+            ghcr.io/${{ github.repository_owner }}/atlas-gateway:${{ github.ref_name }}
+          cosign sign --yes \
+            ghcr.io/${{ github.repository_owner }}/atlas-gateway@${{ steps.digests.outputs.gw }}
+
+      - name: Cosign sign (witness: tag + digest)
+        env:
+          COSIGN_EXPERIMENTAL: 1
+        run: |
+          cosign sign --yes \
+            ghcr.io/${{ github.repository_owner }}/atlas-witness:${{ github.ref_name }}
+          cosign sign --yes \
+            ghcr.io/${{ github.repository_owner }}/atlas-witness@${{ steps.digests.outputs.wt }}


### PR DESCRIPTION
Add Cosign keyless signing to release workflow after GHCR push. Signs both tag and digest for gateway and witness images.